### PR TITLE
Adding transactional execution, with loop execution

### DIFF
--- a/conveyor.go
+++ b/conveyor.go
@@ -173,12 +173,12 @@ func (cnv *Conveyor) Start() error {
 		wg.Add(1)
 		go func(nodeWorker NodeWorker) {
 			defer wg.Done()
-			if err := nodeWorker.StartLoopMode(cnv.ctx); err != nil {
+			if err := nodeWorker.Start(cnv.ctx); err != nil {
 				log.Println("node worker start failed", err)
 				return
 			}
 
-			if err := nodeWorker.WaitAndStop(); err != nil {
+			if err := nodeWorker.WaitAndStop(cnv.ctx); err != nil {
 				log.Println("node worker stop failed", err)
 			}
 		}(nodeWorker)

--- a/conveyor.go
+++ b/conveyor.go
@@ -8,12 +8,6 @@ import (
 	"time"
 )
 
-// Message struct stores one unit of message that conveyor passed back for logging
-type Message struct {
-	Err  error
-	Text string
-}
-
 // Conveyor to run the graph
 type Conveyor struct {
 	Name         string
@@ -47,7 +41,12 @@ func (cnv *Conveyor) Done() <-chan struct{} {
 }
 
 // Progress returns a channel which is regularly updated with progress %
-func (cnv *Conveyor) Progress() <-chan float64 { return cnv.progress }
+func (cnv *Conveyor) Progress() <-chan float64 {
+	if cnv.needProgress {
+		return cnv.progress
+	}
+	return nil
+}
 
 // Logs returns a channel on which Conveyor Statuses will be published
 func (cnv *Conveyor) Logs() <-chan Message {
@@ -211,9 +210,10 @@ func (cnv *Conveyor) Start() error {
 
 // Stop Conveyor by cancelling context. It's used to kill a campaign while it's running.
 // No need to call it if campaign is finishing on it's own
-func (cnv *Conveyor) Stop() {
+func (cnv *Conveyor) Stop() time.Duration {
 	// Cancel ctx
 	cnv.cleanup() // cleanup() will be called from here, in case of killing conveyor
+	return cnv.duration
 }
 
 // cleanup should be called in all the termination cases: success, kill, & timeout
@@ -260,69 +260,4 @@ trackProgress:
 		}
 	}
 
-}
-
-// CtxData stores the information that is stored inside a conveyor, useful for it's lifecycle.ConveyorData
-// Any fields only useful for initialization shouldn't be here
-type CtxData struct {
-	Name string
-
-	logs           chan Message
-	status         chan string
-	cancelProgress context.CancelFunc
-	// cancelAll      context.CancelFunc
-
-}
-
-// CnvContext is a wrapper over context.Context
-// To avoid sacrificing type checking with context.WithValue() wherever it's not needed
-type CnvContext struct {
-	context.Context
-
-	cancelOnce sync.Once
-	Data       CtxData
-}
-
-// WithCancel is a wrapper on context.WithCancel() for CnvContext type,
-// that also copies the Data to new context
-func (ctx *CnvContext) WithCancel() *CnvContext {
-	newctx, cancel := context.WithCancel(ctx.Context)
-	cnvContext := &CnvContext{
-		Context: newctx,
-		Data:    ctx.Data,
-	}
-	cnvContext.Data.cancelProgress = cancel
-
-	return cnvContext
-}
-
-// WithTimeout is a wrapper on context.WithTimeout() for CnvContext type,
-// that also copies the Data to new context
-func (ctx *CnvContext) WithTimeout(timeout time.Duration) *CnvContext {
-	newctx, cancel := context.WithTimeout(ctx.Context, timeout)
-	cnvContext := &CnvContext{
-		Context: newctx,
-		Data:    ctx.Data,
-	}
-	cnvContext.Data.cancelProgress = cancel
-
-	return cnvContext
-}
-
-// Cancel the derived context, along with closing internal channels
-// It has been made to follow the "non-panic multiple cancel" behaviour of built-in context
-func (ctx *CnvContext) Cancel() {
-	if ctx.Data.cancelProgress != nil {
-		ctx.Data.cancelProgress()
-
-		ctx.cancelOnce.Do(func() {
-			if ctx.Data.logs != nil {
-				close(ctx.Data.logs)
-			}
-
-			if ctx.Data.logs != nil {
-				close(ctx.Data.status)
-			}
-		})
-	}
 }

--- a/custom_context.go
+++ b/custom_context.go
@@ -1,0 +1,126 @@
+package conveyor
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Message struct stores one unit of message that conveyor passed back for logging
+type Message struct {
+	Text     string
+	LogLevel int32
+	// Err      error
+}
+
+// CtxData stores the information that is stored inside a conveyor, useful for it's lifecycle.ConveyorData
+// Any fields only useful for initialization shouldn't be here
+type CtxData struct {
+	Name string
+
+	logs           chan Message
+	status         chan string
+	cancelProgress context.CancelFunc
+	// cancelAll      context.CancelFunc
+
+}
+
+// CnvContext is a wrapper over context.Context
+// To avoid sacrificing type checking with context.WithValue() wherever it's not needed
+type CnvContext struct {
+	context.Context
+
+	cancelOnce sync.Once
+	Data       CtxData
+}
+
+// WithCancel is a wrapper on context.WithCancel() for CnvContext type,
+// that also copies the Data to new context
+func (ctx *CnvContext) WithCancel() *CnvContext {
+	newctx, cancel := context.WithCancel(ctx.Context)
+	cnvContext := &CnvContext{
+		Context: newctx,
+		Data:    ctx.Data,
+	}
+	cnvContext.Data.cancelProgress = cancel
+
+	return cnvContext
+}
+
+// WithTimeout is a wrapper on context.WithTimeout() for CnvContext type,
+// that also copies the Data to new context
+func (ctx *CnvContext) WithTimeout(timeout time.Duration) *CnvContext {
+	newctx, cancel := context.WithTimeout(ctx.Context, timeout)
+	cnvContext := &CnvContext{
+		Context: newctx,
+		Data:    ctx.Data,
+	}
+	cnvContext.Data.cancelProgress = cancel
+
+	return cnvContext
+}
+
+// Cancel the derived context, along with closing internal channels
+// It has been made to follow the "non-panic multiple cancel" behaviour of built-in context
+func (ctx *CnvContext) Cancel() {
+	if ctx.Data.cancelProgress != nil {
+		ctx.Data.cancelProgress()
+	}
+
+	ctx.cancelOnce.Do(func() {
+		if ctx.Data.logs != nil {
+			close(ctx.Data.logs)
+		}
+
+		if ctx.Data.logs != nil {
+			close(ctx.Data.status)
+		}
+	})
+
+}
+
+// SendLog sends conveyor's internal logs to be available on conveyor.Logs()
+func (ctx *CnvContext) SendLog(logLevel int32, text string, err error) {
+	if err != nil {
+		text = fmt.Sprintf("conveyor: %s, [err: %s]\n", text, err)
+	} else {
+		text = fmt.Sprintf("conveyor: %s\n", text)
+	}
+	msg := Message{
+		LogLevel: logLevel,
+		Text:     text,
+	}
+
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		return
+	case ctx.Data.logs <- msg:
+	default:
+	}
+}
+
+// SendStatus sends conveyor's internal logs to be available on conveyor.Status()
+func (ctx *CnvContext) SendStatus(status string) {
+
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		return
+	case ctx.Data.status <- status:
+	default:
+		<-ctx.Data.status // If not consumed, throw away old status and update with new value
+		ctx.Data.status <- status
+	}
+}

--- a/executor.go
+++ b/executor.go
@@ -1,9 +1,12 @@
 package conveyor
 
+import "errors"
+
 // NodeExecutor interface binds to nodes that have the capability to fetch intermidiate data, and forward it to next node
 type NodeExecutor interface {
 	GetName() string
-	Execute(ctx *CnvContext, inChan <-chan map[string]interface{}, outChan chan<- map[string]interface{})
+	ExecuteLoop(ctx *CnvContext, inChan <-chan map[string]interface{}, outChan chan<- map[string]interface{})
+	Execute(ctx *CnvContext, inData map[string]interface{}) (map[string]interface{}, error)
 	Count() int
 	CleanUp() error
 }
@@ -22,6 +25,30 @@ type ConcreteNodeExecutor struct {
 	Name string
 	Data interface{}
 }
+
+var (
+
+	// ErrExecuteNotImplemented error
+	ErrExecuteNotImplemented = errors.New("This executor doesn't implement Execute() method")
+
+	// ErrExecuteLoopNotImplemented error
+	ErrExecuteLoopNotImplemented = errors.New("This executor doesn't implement ExecuteLoop() method")
+
+	// ErrSourceExhausted error
+	ErrSourceExhausted = errors.New("Source executor is exhausted")
+	// ErrSourceInternal error
+	ErrSourceInternal = errors.New("Source executor internal error")
+
+	// ErrFetchRejected error
+	ErrFetchRejected = errors.New("Fetch executor rejected the transaction")
+	// ErrFetchInternal error
+	ErrFetchInternal = errors.New("Fetch executor internal error")
+
+	// ErrSinkRejected error
+	ErrSinkRejected = errors.New("Sink executor rejected data")
+	// ErrSinkInternal error
+	ErrSinkInternal = errors.New("Sink executor internal error")
+)
 
 // Count returns the number of executors required
 func (cnh *ConcreteNodeExecutor) Count() int {

--- a/executor.go
+++ b/executor.go
@@ -5,7 +5,7 @@ import "errors"
 // NodeExecutor interface binds to nodes that have the capability to fetch intermidiate data, and forward it to next node
 type NodeExecutor interface {
 	GetName() string
-	ExecuteLoop(ctx *CnvContext, inChan <-chan map[string]interface{}, outChan chan<- map[string]interface{})
+	ExecuteLoop(ctx *CnvContext, inChan <-chan map[string]interface{}, outChan chan<- map[string]interface{}) error
 	Execute(ctx *CnvContext, inData map[string]interface{}) (map[string]interface{}, error)
 	Count() int
 	CleanUp() error
@@ -30,6 +30,9 @@ var (
 
 	// ErrExecuteNotImplemented error
 	ErrExecuteNotImplemented = errors.New("This executor doesn't implement Execute() method")
+
+	// ErrInvalidWorkerMode error
+	ErrInvalidWorkerMode = errors.New("Invalid worker mode. pick either conveyor.WorkerModeTransaction or conveyor.WorkerModeLoop")
 
 	// ErrExecuteLoopNotImplemented error
 	ErrExecuteLoopNotImplemented = errors.New("This executor doesn't implement ExecuteLoop() method")

--- a/executor.go
+++ b/executor.go
@@ -1,10 +1,14 @@
 package conveyor
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // NodeExecutor interface binds to nodes that have the capability to fetch intermidiate data, and forward it to next node
 type NodeExecutor interface {
 	GetName() string
+	GetUniqueIdentifier() string
 	ExecuteLoop(ctx *CnvContext, inChan <-chan map[string]interface{}, outChan chan<- map[string]interface{}) error
 	Execute(ctx *CnvContext, inData map[string]interface{}) (map[string]interface{}, error)
 	Count() int
@@ -52,6 +56,11 @@ var (
 	// ErrSinkInternal error
 	ErrSinkInternal = errors.New("Sink executor internal error")
 )
+
+// GetUniqueIdentifier can be used to fetch a unique string identifying the executor
+func (cnh *ConcreteNodeExecutor) GetUniqueIdentifier() string {
+	return fmt.Sprintf("%s", cnh.Name)
+}
 
 // Count returns the number of executors required
 func (cnh *ConcreteNodeExecutor) Count() int {

--- a/fetchworker.go
+++ b/fetchworker.go
@@ -63,13 +63,13 @@ func (fwp *FetchWorkerPool) SetOutputChannel(outChan chan map[string]interface{}
 	return nil
 }
 
-// Start FetchWorkerPool
-func (fwp *FetchWorkerPool) Start(ctx *CnvContext) error {
+// StartLoopMode FetchWorkerPool
+func (fwp *FetchWorkerPool) StartLoopMode(ctx *CnvContext) error {
 	for i := 0; i < fwp.Executor.Count(); i++ {
 		fwp.Wg.Add(1)
 		go func() {
 			defer fwp.Wg.Done()
-			fwp.Executor.Execute(ctx, fwp.inputChannel, fwp.outputChannel)
+			fwp.Executor.ExecuteLoop(ctx, fwp.inputChannel, fwp.outputChannel)
 		}()
 	}
 	return nil

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,12 @@
+hash: 1c46833cf8fa0255503047985461d00172619c9bb8a98265e2de4c42b159f1fb
+updated: 2018-10-07T18:03:36.373238694+05:30
+imports:
+- name: golang.org/x/net
+  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
+  subpackages:
+  - context
+- name: golang.org/x/sync
+  version: 1d60e4601c6fd243af51cc01ddf169918a5407ca
+  subpackages:
+  - semaphore
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,5 @@
+package: hawker/vendor/github.com/tushar2708/conveyor
+import:
+- package: golang.org/x/sync
+  subpackages:
+  - semaphore

--- a/sinkworker.go
+++ b/sinkworker.go
@@ -26,14 +26,14 @@ func (swp *SinkWorkerPool) CreateChannels(buffer int) {
 	swp.inputChannel = make(chan map[string]interface{}, buffer)
 }
 
-// Start SinkWorkerPool
-func (swp *SinkWorkerPool) Start(ctx *CnvContext) error {
+// StartLoopMode SinkWorkerPool
+func (swp *SinkWorkerPool) StartLoopMode(ctx *CnvContext) error {
 	for i := 0; i < swp.Executor.Count(); i++ {
 		swp.Wg.Add(1)
 
 		go func() {
 			defer swp.Wg.Done()
-			swp.Executor.Execute(ctx, swp.inputChannel, nil)
+			swp.Executor.ExecuteLoop(ctx, swp.inputChannel, nil)
 		}()
 	}
 	return nil

--- a/sinkworker.go
+++ b/sinkworker.go
@@ -1,5 +1,12 @@
 package conveyor
 
+import (
+	"log"
+
+	"github.com/sudersen/glog"
+	"golang.org/x/sync/semaphore"
+)
+
 // SinkWorkerPool struct provides the worker pool infra for Sink interface
 type SinkWorkerPool struct {
 	ConcreteNodeWorker
@@ -7,13 +14,14 @@ type SinkWorkerPool struct {
 }
 
 // NewSinkWorkerPool creates a new SinkWorkerPool
-func NewSinkWorkerPool(executor NodeExecutor) NodeWorker {
+func NewSinkWorkerPool(executor NodeExecutor, mode WorkerMode) NodeWorker {
 
 	swp := &SinkWorkerPool{
 		ConcreteNodeWorker: ConcreteNodeWorker{
 			WPool: WPool{
 				Name: executor.GetName() + "_worker",
 			},
+			Mode:     mode,
 			Executor: executor,
 		},
 	}
@@ -26,16 +34,76 @@ func (swp *SinkWorkerPool) CreateChannels(buffer int) {
 	swp.inputChannel = make(chan map[string]interface{}, buffer)
 }
 
-// StartLoopMode SinkWorkerPool
-func (swp *SinkWorkerPool) StartLoopMode(ctx *CnvContext) error {
+// Start Sink Worker Pool
+func (swp *SinkWorkerPool) Start(ctx *CnvContext) error {
+	if swp.Mode == WorkerModeTransaction {
+		return swp.startTransactionMode(ctx)
+	} else if swp.Mode == WorkerModeLoop {
+		return swp.startLoopMode(ctx)
+	} else {
+		return ErrInvalidWorkerMode
+	}
+}
+
+// startLoopMode SinkWorkerPool
+func (swp *SinkWorkerPool) startLoopMode(ctx *CnvContext) error {
 	for i := 0; i < swp.Executor.Count(); i++ {
 		swp.Wg.Add(1)
 
 		go func() {
 			defer swp.Wg.Done()
 			swp.Executor.ExecuteLoop(ctx, swp.inputChannel, nil)
+
+			if err := swp.Executor.ExecuteLoop(ctx, swp.inputChannel, nil); err != nil {
+				if err == ErrExecuteLoopNotImplemented {
+					glog.V(3).Infof("Executor:[%s], Err:[%s]", swp.Executor.GetName(), err.Error())
+					log.Fatalf("Improper setup of Executor[%s], ExecuteLoop() method is required", swp.Executor.GetName())
+				} else {
+					return
+				}
+			}
+
 		}()
 	}
+	return nil
+}
+
+// startTransactionMode starts SourceWorkerPool in transaction mode
+func (swp *SinkWorkerPool) startTransactionMode(ctx *CnvContext) error {
+	wCnt := swp.Executor.Count()
+	sem := semaphore.NewWeighted(int64(wCnt))
+
+workerLoop:
+	for {
+
+		select {
+		case <-ctx.Done():
+			break workerLoop
+		default:
+		}
+
+		if err := sem.Acquire(ctx, 1); err != nil {
+			log.Printf("Failed to acquire semaphore: %v", err)
+			break
+		}
+
+		go func() {
+			defer sem.Release(1)
+			in, ok := <-swp.inputChannel
+			if ok {
+				_, err := swp.Executor.Execute(ctx, in)
+				if err != nil {
+					if err == ErrExecuteNotImplemented {
+						glog.V(3).Infof("Executor:[%s], Err:[%s]", swp.Executor.GetName(), err.Error())
+						log.Fatalf("Improper setup of Executor[%s], Execute() method is required", swp.Executor.GetName())
+					}
+				}
+			}
+			return
+		}()
+
+	}
+
 	return nil
 }
 
@@ -66,8 +134,16 @@ func (swp *SinkWorkerPool) WorkerType() string {
 }
 
 // WaitAndStop SinkWorkerPool
-func (swp *SinkWorkerPool) WaitAndStop() error {
-	swp.Wg.Wait()
+func (swp *SinkWorkerPool) WaitAndStop(ctx *CnvContext) error {
+
+	if swp.Mode == WorkerModeTransaction {
+		if err := swp.sem.Acquire(ctx, int64(swp.Executor.Count())); err != nil {
+			log.Printf("Failed to acquire semaphore: %v", err)
+		}
+	} else {
+		swp.Wg.Wait()
+	}
+
 	swp.Executor.CleanUp()
 	return nil
 }

--- a/sourceworker.go
+++ b/sourceworker.go
@@ -44,13 +44,13 @@ func (swp *SourceWorkerPool) SetOutputChannel(outChan chan map[string]interface{
 	return nil
 }
 
-// Start SourceWorkerPool
-func (swp *SourceWorkerPool) Start(ctx *CnvContext) error {
+// StartLoopMode SourceWorkerPool
+func (swp *SourceWorkerPool) StartLoopMode(ctx *CnvContext) error {
 	for i := 0; i < swp.Executor.Count(); i++ {
 		swp.Wg.Add(1)
 		go func() {
 			defer swp.Wg.Done()
-			swp.Executor.Execute(ctx, nil, swp.outputChannel)
+			swp.Executor.ExecuteLoop(ctx, nil, swp.outputChannel)
 		}()
 	}
 	return nil

--- a/sourceworker.go
+++ b/sourceworker.go
@@ -1,5 +1,12 @@
 package conveyor
 
+import (
+	"log"
+
+	"github.com/sudersen/glog"
+	"golang.org/x/sync/semaphore"
+)
+
 // SourceWorkerPool struct provides the worker pool infra for Source interface
 type SourceWorkerPool struct {
 	ConcreteNodeWorker
@@ -8,13 +15,14 @@ type SourceWorkerPool struct {
 }
 
 // NewSourceWorkerPool creates a new SourceWorkerPool
-func NewSourceWorkerPool(executor NodeExecutor) NodeWorker {
+func NewSourceWorkerPool(executor NodeExecutor, mode WorkerMode) NodeWorker {
 
 	swp := &SourceWorkerPool{
 		ConcreteNodeWorker: ConcreteNodeWorker{
 			WPool: WPool{
 				Name: executor.GetName() + "_worker",
 			},
+			Mode:     mode,
 			Executor: executor,
 		},
 	}
@@ -44,15 +52,69 @@ func (swp *SourceWorkerPool) SetOutputChannel(outChan chan map[string]interface{
 	return nil
 }
 
-// StartLoopMode SourceWorkerPool
-func (swp *SourceWorkerPool) StartLoopMode(ctx *CnvContext) error {
+// Start Source Worker Pool
+func (swp *SourceWorkerPool) Start(ctx *CnvContext) error {
+	if swp.Mode == WorkerModeTransaction {
+		return swp.startTransactionMode(ctx)
+	} else if swp.Mode == WorkerModeLoop {
+		return swp.startLoopMode(ctx)
+	} else {
+		return ErrInvalidWorkerMode
+	}
+}
+
+// startLoopMode SourceWorkerPool
+func (swp *SourceWorkerPool) startLoopMode(ctx *CnvContext) error {
 	for i := 0; i < swp.Executor.Count(); i++ {
 		swp.Wg.Add(1)
 		go func() {
 			defer swp.Wg.Done()
-			swp.Executor.ExecuteLoop(ctx, nil, swp.outputChannel)
+			if err := swp.Executor.ExecuteLoop(ctx, nil, swp.outputChannel); err != nil {
+				if err == ErrExecuteLoopNotImplemented {
+					glog.V(3).Infof("Executor:[%s], Err:[%s]", swp.Executor.GetName(), err.Error())
+					log.Fatalf("Improper setup of Executor[%s], ExecuteLoop() method is required", swp.Executor.GetName())
+				} else {
+					return
+				}
+			}
 		}()
 	}
+	return nil
+}
+
+// startTransactionMode starts SourceWorkerPool in transaction mode
+func (swp *SourceWorkerPool) startTransactionMode(ctx *CnvContext) error {
+	wCnt := swp.Executor.Count()
+	swp.sem = semaphore.NewWeighted(int64(wCnt))
+
+workerLoop:
+	for {
+
+		select {
+		case <-ctx.Done():
+			break workerLoop
+		default:
+		}
+
+		if err := swp.sem.Acquire(ctx, 1); err != nil {
+			log.Printf("Failed to acquire semaphore: %v", err)
+			break
+		}
+
+		go func() {
+			defer swp.sem.Release(1)
+			out, err := swp.Executor.Execute(ctx, nil)
+			if err == nil {
+				swp.outputChannel <- out
+			} else if err == ErrExecuteNotImplemented {
+				glog.V(3).Infof("Executor:[%s], Err:[%s]", swp.Executor.GetName(), err.Error())
+				log.Fatalf("Improper setup of Executor[%s], Execute() method is required", swp.Executor.GetName())
+			}
+			return
+		}()
+
+	}
+
 	return nil
 }
 
@@ -62,8 +124,14 @@ func (swp *SourceWorkerPool) WorkerType() string {
 }
 
 // WaitAndStop SourceWorkerPool
-func (swp *SourceWorkerPool) WaitAndStop() error {
-	swp.Wg.Wait()
+func (swp *SourceWorkerPool) WaitAndStop(ctx *CnvContext) error {
+	if swp.Mode == WorkerModeTransaction {
+		if err := swp.sem.Acquire(ctx, int64(swp.Executor.Count())); err != nil {
+			log.Printf("Failed to acquire semaphore: %v", err)
+		}
+	} else {
+		swp.Wg.Wait()
+	}
 	swp.Executor.CleanUp()
 	close(swp.outputChannel)
 	return nil

--- a/utils.go
+++ b/utils.go
@@ -2,33 +2,6 @@ package conveyor
 
 import "errors"
 
-func sendStatus(ctx *CnvContext, status string) error {
-
-	select {
-	case <-ctx.Done():
-		return nil
-	case ctx.Data.status <- status:
-	default:
-		<-ctx.Data.status // If not consumed, throw away old status and update with new value
-		ctx.Data.status <- status
-	}
-	return nil
-}
-
-func sendLogs(ctx *CnvContext, text string, err error) error {
-
-	logEntry := Message{Text: text, Err: err}
-
-	select {
-	case <-ctx.Done():
-		return nil
-	case ctx.Data.logs <- logEntry:
-	default:
-		ctx.Data.logs <- logEntry
-	}
-	return nil
-}
-
 // LinkWorker2Worker links two NodeWorkers, maps input channel of a b on output channel of a
 func LinkWorker2Worker(a NodeWorker, b NodeWorker) error {
 	ch, err := b.GetInputChannel()

--- a/workerpool.go
+++ b/workerpool.go
@@ -56,8 +56,9 @@ type WPool struct {
 // ConcreteNodeWorker to run different nodes of comex graph
 type ConcreteNodeWorker struct {
 	WPool
-	Mode     WorkerMode
-	Executor NodeExecutor
+	WorkerCount int
+	Mode        WorkerMode
+	Executor    NodeExecutor
 }
 
 // ConcreteJointWorker to run different nodes of comex graph

--- a/workerpool.go
+++ b/workerpool.go
@@ -3,6 +3,8 @@ package conveyor
 import (
 	"errors"
 	"sync"
+
+	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -14,6 +16,25 @@ const (
 	SinkWorkerType = "SINK_WORKER"
 	// PlumbingWorkerType constant
 	PlumbingWorkerType = "PLUMBING_WORKER"
+)
+
+// WorkerMode decides if worker would run in loop mode or single transaction mode
+type WorkerMode uint8
+
+const (
+	// WorkerModeTransaction is the worker mode in which executor just needs to implement Execute(ctx) method
+	// and doesn't need to handle worker's channel or shutdown of worker.
+	// But executor should still monitor ctx.Done() to shutdown or cleanup/close any files/connections, etc that it opens.
+	// This one helps keep the executor code leaner & simple
+	// This mode is useful for most of the cases, including executors that do file I/O, database lookup, remote API call
+	WorkerModeTransaction = WorkerMode(iota + 10)
+
+	// WorkerModeLoop is the worker mode in which executor just needs to implement ExecuteLoop(ctx, inChan, outChan) method
+	// and has to handle the copying of data from/to channels (except, closing them), executor will also need to ensure
+	// that it monitors ctx.Done() to shutdown worker, in case of any error.
+	// Needs more code, use only if you are ready to peek into how it works.
+	// Some use cases are, where you can't fetch data on-demand with a function call. Eg. Running an NPI server as source
+	WorkerModeLoop
 )
 
 var (
@@ -29,11 +50,13 @@ type WPool struct {
 	// Executor    common.NodeExecutor
 	sigChannel chan interface{}
 	Wg         sync.WaitGroup
+	sem        *semaphore.Weighted
 }
 
 // ConcreteNodeWorker to run different nodes of comex graph
 type ConcreteNodeWorker struct {
 	WPool
+	Mode     WorkerMode
 	Executor NodeExecutor
 }
 
@@ -45,8 +68,8 @@ type ConcreteJointWorker struct {
 
 // NodeWorker interface binds to nodes that have the capability to fetch intermidiate data, and forward it to next node
 type NodeWorker interface {
-	StartLoopMode(ctx *CnvContext) error
-	WaitAndStop() error
+	Start(ctx *CnvContext) error
+	WaitAndStop(ctx *CnvContext) error
 	CreateChannels(int)
 	WorkerType() string
 	SetInputChannel(chan map[string]interface{}) error

--- a/workerpool.go
+++ b/workerpool.go
@@ -45,7 +45,7 @@ type ConcreteJointWorker struct {
 
 // NodeWorker interface binds to nodes that have the capability to fetch intermidiate data, and forward it to next node
 type NodeWorker interface {
-	Start(ctx *CnvContext) error
+	StartLoopMode(ctx *CnvContext) error
 	WaitAndStop() error
 	CreateChannels(int)
 	WorkerType() string


### PR DESCRIPTION
Till now Execute() left all the responsibility of synchronisation(monitoring ctx.Done() ) on the user.
While ExecuteLoop() is still useful at few places like running an API server as source executor, single unit Execute() is a better fit for scenarios like reading files, hitting 3rd party APIs, evaluation, etc. And it makes the LOC needed to add an executor much lesser than current implementation.